### PR TITLE
Replace Math.floor() with Math.trunc() for integer division

### DIFF
--- a/docs/week02/index.html
+++ b/docs/week02/index.html
@@ -91,7 +91,7 @@
         <tbody>
           <tr>
             <td>a//b</td>
-            <td>Math.floor(a/b)</td>
+            <td>Math.trunc(a/b)</td>
           </tr>
           <tr>
             <td>a &lt&gt b</td>


### PR DESCRIPTION
While a lot of people use `Math.floor(x/y)` for integer division, this doesn't work as expected for negative numbers:

```
// Outputs -3
Math.floor(-5 / 2)
```
[Math.trunc()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc) was added in ES6 to address this.
